### PR TITLE
Adding execute permission to install.sh file

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ A comprehensive guide on how to run the server implementation of a certain turn 
 3. When you first open the application it may ask you for notifications permission press ok (android 13 and up)
 4. After everything finishes copy the command bellow and paste it onto the terminal by long pressing and clicking paste (This too will take a while be patient)
 ```sh
-apt install git -y && git clone https://github.com/kostas214/LunarCore-on-Android.git && cd LunarCore-on-Android && . install.sh
+apt install git -y && git clone https://github.com/kostas214/LunarCore-on-Android.git && cd LunarCore-on-Android && chmod +x install.sh && . install.sh
 ```
 5. If the server fails to start type ```stop``` and type ```. start.sh```
    


### PR DESCRIPTION
when cloning into repository, you get access denied to execute, to resolve this you would want to give the permission to the file using chmod, this may likely be needed on the rest of shell scripts if missing for other shell scripts.